### PR TITLE
Move scraps into part three backlog

### DIFF
--- a/data/blog-posts/backlog/digital-sovereignty-stack-2026.md
+++ b/data/blog-posts/backlog/digital-sovereignty-stack-2026.md
@@ -56,6 +56,58 @@ The important part is that the decision is deliberate.
 
 ---
 
+## Practical Threads To Pull Into This Post
+
+This part should probably stay closer to tools, workflows, and trade-offs than the first two posts.
+
+Possible areas to cover:
+
+- Practical de-Googling, de-Microsofting, and reducing dependence on other large ecosystems.
+- The tools and services I eventually settled on.
+- The ones I tried and abandoned.
+- The ones I still tolerate because the convenience is worth it.
+- Self-hosting services without turning into a full-time system administrator.
+- Privacy-friendly communication.
+- AI, data brokers, and the changing value of personal information.
+- Practical resources that make privacy significantly easier.
+
+The goal should not be a universal checklist. It should be closer to: here is how I evaluated the stack, here is what changed, here is what stayed, and here is why.
+
+---
+
+## Questions Worth Keeping
+
+These are probably useful as a structure for the practical sections, or as a closing checklist.
+
+- Do I still use this account?
+- Does this company still need my personal data?
+- Could I replace this service with something more privacy-friendly?
+- What happens if this company is breached tomorrow?
+- Do I actually trust this organization with my information?
+- How many online accounts do I actually have?
+- Which companies still store my data?
+- Has AI changed the value of my personal data?
+- Should deleting an account be as easy as creating one?
+- How much convenience am I willing to trade for privacy?
+
+Small changes compound surprisingly quickly. Reclaiming your digital life is not a single decision. It is a continuous process of becoming more intentional about where your data lives, which services you rely on, and who gets to keep what.
+
+---
+
+## Probably A Separate GDPR Workflow Post
+
+The scraps file also has a longer argument about GDPR deletion requests, organizational failure, broken privacy portals, legal clarity versus operational mess, and the difference between Article 17 compliance and actual digital sovereignty.
+
+That material feels useful, but not for this stack/tools post. It probably belongs in a more practical deletion-workflow follow-up covering:
+
+- My GDPR deletion workflow.
+- Email templates that consistently worked.
+- What to pay attention to in privacy policies.
+- Useful services such as YourDigitalRights.org.
+- Examples of companies with good and bad deletion processes.
+
+---
+
 ## Notes & References
 
 Below is a list of references so you can scan everything in one place.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github.io",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "github.io",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "d3-force": "^3.0.0",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github.io",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary
- move the relevant scraps material into the new part-three backlog draft
- add practical thread/checklist notes for the digital sovereignty stack follow-up
- preserve a short pointer to the longer GDPR workflow material as probably separate from this stack/tools post
- bump package version to 0.1.2

## Notes
- I did not delete data/blog-posts/scraps.MD; this PR just moves the useful part-three material so you can decide whether to remove the scraps file afterward.
- The long GDPR/organizational argument in scraps did not feel like part-three stack material, so I summarized it as a likely separate workflow post instead of dumping the whole section into this draft.

## Verification
- parsed digital-sovereignty-stack-2026.md frontmatter/content with gray-matter
- git diff --check
- npm run build passes

## Build caveat
- npm run build still makes Next.js try to rewrite tsconfig.json from jsx preserve to jsx react-jsx; I reverted that generated side effect, same as before.